### PR TITLE
[Feature] Notification 엔티티를 저장하고, kafka에 발행된 토픽을 구독하고 알림 데이터 저장하는 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ ext {
 }
 
 dependencies {
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/build.gradle
+++ b/build.gradle
@@ -28,13 +28,16 @@ ext {
 }
 
 dependencies {
+//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
-	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
+//	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.kafka:spring-kafka'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext {
 dependencies {
 //	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
-//	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.kafka:spring-kafka'

--- a/src/main/java/com/parkmate/notificationservice/NotificationServiceApplication.java
+++ b/src/main/java/com/parkmate/notificationservice/NotificationServiceApplication.java
@@ -1,8 +1,12 @@
-package com.parkmate.notification_service;
+package com.parkmate.notificationservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 
+@EnableMongoAuditing
+@EnableDiscoveryClient
 @SpringBootApplication
 public class NotificationServiceApplication {
 

--- a/src/main/java/com/parkmate/notificationservice/common/config/KafkaConfig.java
+++ b/src/main/java/com/parkmate/notificationservice/common/config/KafkaConfig.java
@@ -37,7 +37,7 @@ public class KafkaConfig {
     }
 
     @Bean
-    public ConsumerFactory<String, NotificationEvent> reservationCompleteEventConsumerFactory() {
+    public ConsumerFactory<String, NotificationEvent> notificationEventConsumerFactory() {
         return new DefaultKafkaConsumerFactory<>(
                 notificationConsumerConfigs(),
                 new StringDeserializer(),
@@ -46,9 +46,9 @@ public class KafkaConfig {
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, NotificationEvent> reservationCompleteEventListener() {
+    public ConcurrentKafkaListenerContainerFactory<String, NotificationEvent> notificationEventListener() {
         ConcurrentKafkaListenerContainerFactory<String, NotificationEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(reservationCompleteEventConsumerFactory());
+        factory.setConsumerFactory(notificationEventConsumerFactory());
 
         return factory;
     }

--- a/src/main/java/com/parkmate/notificationservice/common/config/KafkaConfig.java
+++ b/src/main/java/com/parkmate/notificationservice/common/config/KafkaConfig.java
@@ -1,0 +1,55 @@
+package com.parkmate.notificationservice.common.config;
+
+import com.parkmate.notificationservice.notification.event.NotificationEvent;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServer;
+
+    @Bean
+    public Map<String, Object> notificationConsumerConfigs() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "notification-service");
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, NotificationEvent.class);
+
+        return props;
+    }
+
+    @Bean
+    public ConsumerFactory<String, NotificationEvent> reservationCompleteEventConsumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(
+                notificationConsumerConfigs(),
+                new StringDeserializer(),
+                new ErrorHandlingDeserializer<>(new JsonDeserializer<>(NotificationEvent.class, false))
+        );
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, NotificationEvent> reservationCompleteEventListener() {
+        ConcurrentKafkaListenerContainerFactory<String, NotificationEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(reservationCompleteEventConsumerFactory());
+
+        return factory;
+    }
+}

--- a/src/main/java/com/parkmate/notificationservice/common/entity/BaseEntity.java
+++ b/src/main/java/com/parkmate/notificationservice/common/entity/BaseEntity.java
@@ -1,0 +1,17 @@
+package com.parkmate.notificationservice.common.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/parkmate/notificationservice/notification/application/NotificationReactiveService.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/application/NotificationReactiveService.java
@@ -1,0 +1,16 @@
+package com.parkmate.notificationservice.notification.application;
+
+import com.parkmate.notificationservice.notification.infrastructure.NotificationReactiveRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationReactiveService {
+
+    private final NotificationReactiveRepository notificationReactiveRepository;
+
+    public void getNotifications() {
+
+    }
+}

--- a/src/main/java/com/parkmate/notificationservice/notification/application/NotificationService.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/application/NotificationService.java
@@ -1,8 +1,13 @@
 package com.parkmate.notificationservice.notification.application;
 
 import com.parkmate.notificationservice.notification.dto.NotificationEventDto;
+import com.parkmate.notificationservice.notification.dto.response.NotificationResponseDto;
+
+import java.util.List;
 
 public interface NotificationService {
 
     void createNotification(NotificationEventDto notificationEventDto);
+
+    List<NotificationResponseDto> getNotificationsByReceiverUuid(String receiverUuid);
 }

--- a/src/main/java/com/parkmate/notificationservice/notification/application/NotificationService.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/application/NotificationService.java
@@ -1,0 +1,8 @@
+package com.parkmate.notificationservice.notification.application;
+
+import com.parkmate.notificationservice.notification.dto.NotificationEventDto;
+
+public interface NotificationService {
+
+    void createNotification(NotificationEventDto notificationEventDto);
+}

--- a/src/main/java/com/parkmate/notificationservice/notification/application/NotificationServiceImpl.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/application/NotificationServiceImpl.java
@@ -1,20 +1,24 @@
 package com.parkmate.notificationservice.notification.application;
 
 import com.parkmate.notificationservice.notification.dto.NotificationEventDto;
-import com.parkmate.notificationservice.notification.infrastructure.NotificationRepository;
+import com.parkmate.notificationservice.notification.infrastructure.NotificationReactiveRepository;
+import com.parkmate.notificationservice.notification.infrastructure.NotificationRestRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class NotificationServiceImpl implements NotificationService {
 
-    private final NotificationRepository notificationRepository;
+    private final NotificationRestRepository notificationRestRepository;
 
     @Transactional
     @Override
     public void createNotification(NotificationEventDto notificationEventDto) {
-        notificationRepository.save(notificationEventDto.toEntity());
+        notificationRestRepository.save(notificationEventDto.toEntity());
+        log.info("Notification created: {}", notificationEventDto);
     }
 }

--- a/src/main/java/com/parkmate/notificationservice/notification/application/NotificationServiceImpl.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/application/NotificationServiceImpl.java
@@ -1,0 +1,20 @@
+package com.parkmate.notificationservice.notification.application;
+
+import com.parkmate.notificationservice.notification.dto.NotificationEventDto;
+import com.parkmate.notificationservice.notification.infrastructure.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional
+    @Override
+    public void createNotification(NotificationEventDto notificationEventDto) {
+        notificationRepository.save(notificationEventDto.toEntity());
+    }
+}

--- a/src/main/java/com/parkmate/notificationservice/notification/application/NotificationServiceImpl.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/application/NotificationServiceImpl.java
@@ -1,12 +1,14 @@
 package com.parkmate.notificationservice.notification.application;
 
 import com.parkmate.notificationservice.notification.dto.NotificationEventDto;
-import com.parkmate.notificationservice.notification.infrastructure.NotificationReactiveRepository;
+import com.parkmate.notificationservice.notification.dto.response.NotificationResponseDto;
 import com.parkmate.notificationservice.notification.infrastructure.NotificationRestRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,5 +22,14 @@ public class NotificationServiceImpl implements NotificationService {
     public void createNotification(NotificationEventDto notificationEventDto) {
         notificationRestRepository.save(notificationEventDto.toEntity());
         log.info("Notification created: {}", notificationEventDto);
+    }
+
+    @Transactional
+    @Override
+    public List<NotificationResponseDto> getNotificationsByReceiverUuid(String receiverUuid) {
+        return notificationRestRepository.findAllByReceiverUuid(receiverUuid)
+                .stream()
+                .map(NotificationResponseDto::from)
+                .toList();
     }
 }

--- a/src/main/java/com/parkmate/notificationservice/notification/domain/Notification.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/domain/Notification.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Document(collection = "notification")
@@ -12,6 +13,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseEntity {
 
+    @Id
     private String id;
     private String receiverUuid;
     private String title;

--- a/src/main/java/com/parkmate/notificationservice/notification/domain/Notification.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/domain/Notification.java
@@ -1,0 +1,33 @@
+package com.parkmate.notificationservice.notification.domain;
+
+import com.parkmate.notificationservice.common.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "notification")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+    private String id;
+    private String receiverUuid;
+    private String title;
+    private String content;
+    private boolean isRead;
+
+    @Builder
+    private Notification(String id,
+                        String receiverUuid,
+                        String title,
+                        String content,
+                        boolean isRead) {
+        this.id = id;
+        this.receiverUuid = receiverUuid;
+        this.title = title;
+        this.content = content;
+        this.isRead = isRead;
+    }
+}

--- a/src/main/java/com/parkmate/notificationservice/notification/domain/NotificationType.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/domain/NotificationType.java
@@ -1,0 +1,19 @@
+package com.parkmate.notificationservice.notification.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum NotificationType {
+
+    CHAT_MESSAGE("채팅 메시지"),
+    EMPTY_SPOT_AVAILABLE("빈 주차 공간 알림"),
+    RESERVATION_COMPLETED("주차 예약 완료"),
+    PARKING_EXIT_REMINDER("주차장 퇴장 알림"),
+    ;
+
+    private final String description;
+
+    NotificationType(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/parkmate/notificationservice/notification/dto/NotificationEventDto.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/dto/NotificationEventDto.java
@@ -1,0 +1,47 @@
+package com.parkmate.notificationservice.notification.dto;
+
+import com.parkmate.notificationservice.notification.domain.Notification;
+import com.parkmate.notificationservice.notification.domain.NotificationType;
+import com.parkmate.notificationservice.notification.event.NotificationEvent;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NotificationEventDto {
+
+    private String receiverUuid;
+    private NotificationType notificationType;
+    private String title;
+    private String content;
+
+    @Builder
+    private NotificationEventDto(String receiverUuid,
+                                NotificationType notificationType,
+                                String title,
+                                String content) {
+        this.receiverUuid = receiverUuid;
+        this.notificationType = notificationType;
+        this.title = title;
+        this.content = content;
+    }
+
+    public static NotificationEventDto from(NotificationEvent notificationEvent) {
+        return NotificationEventDto.builder()
+                .receiverUuid(notificationEvent.getReceiverUuid())
+                .notificationType(notificationEvent.getNotificationType())
+                .title(notificationEvent.getTitle())
+                .content(notificationEvent.getContent())
+                .build();
+    }
+
+    public Notification toEntity() {
+        return Notification.builder()
+                .receiverUuid(this.receiverUuid)
+                .title(this.title)
+                .content(this.content)
+                .isRead(false)
+                .build();
+    }
+}

--- a/src/main/java/com/parkmate/notificationservice/notification/dto/response/NotificationResponseDto.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/dto/response/NotificationResponseDto.java
@@ -1,0 +1,41 @@
+package com.parkmate.notificationservice.notification.dto.response;
+
+import com.parkmate.notificationservice.notification.domain.Notification;
+import com.parkmate.notificationservice.notification.vo.response.NotificationResponseVo;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NotificationResponseDto {
+
+    private String title;
+    private String content;
+    private boolean isRead;
+
+    @Builder
+    private NotificationResponseDto(String title,
+                                   String content,
+                                   boolean isRead) {
+        this.title = title;
+        this.content = content;
+        this.isRead = isRead;
+    }
+
+    public static NotificationResponseDto from(Notification notification) {
+        return NotificationResponseDto.builder()
+                .title(notification.getTitle())
+                .content(notification.getContent())
+                .isRead(notification.isRead())
+                .build();
+    }
+
+    public NotificationResponseVo toVo() {
+        return NotificationResponseVo.builder()
+                .title(title)
+                .content(content)
+                .isRead(isRead)
+                .build();
+    }
+}

--- a/src/main/java/com/parkmate/notificationservice/notification/event/NotificationEvent.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/event/NotificationEvent.java
@@ -1,0 +1,17 @@
+package com.parkmate.notificationservice.notification.event;
+
+import com.parkmate.notificationservice.notification.domain.NotificationType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@NoArgsConstructor
+public class NotificationEvent {
+
+    private String receiverUuid;
+    private NotificationType notificationType;
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/parkmate/notificationservice/notification/infrastructure/NotificationReactiveRepository.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/infrastructure/NotificationReactiveRepository.java
@@ -1,0 +1,8 @@
+package com.parkmate.notificationservice.notification.infrastructure;
+
+import com.parkmate.notificationservice.notification.domain.Notification;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+
+public interface NotificationReactiveRepository extends ReactiveMongoRepository<Notification, String> {
+
+}

--- a/src/main/java/com/parkmate/notificationservice/notification/infrastructure/NotificationRepository.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/infrastructure/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.parkmate.notificationservice.notification.infrastructure;
+
+import com.parkmate.notificationservice.notification.domain.Notification;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface NotificationRepository extends MongoRepository<Notification, String> {
+}

--- a/src/main/java/com/parkmate/notificationservice/notification/infrastructure/NotificationRestRepository.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/infrastructure/NotificationRestRepository.java
@@ -1,8 +1,13 @@
 package com.parkmate.notificationservice.notification.infrastructure;
 
 import com.parkmate.notificationservice.notification.domain.Notification;
+import com.parkmate.notificationservice.notification.dto.response.NotificationResponseDto;
 import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Collection;
+import java.util.List;
 
 public interface NotificationRestRepository extends MongoRepository<Notification, String> {
 
+    List<Notification> findAllByReceiverUuid(String receiverUuid);
 }

--- a/src/main/java/com/parkmate/notificationservice/notification/infrastructure/NotificationRestRepository.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/infrastructure/NotificationRestRepository.java
@@ -3,5 +3,6 @@ package com.parkmate.notificationservice.notification.infrastructure;
 import com.parkmate.notificationservice.notification.domain.Notification;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface NotificationRepository extends MongoRepository<Notification, String> {
+public interface NotificationRestRepository extends MongoRepository<Notification, String> {
+
 }

--- a/src/main/java/com/parkmate/notificationservice/notification/presentation/KafkaConsumerController.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/presentation/KafkaConsumerController.java
@@ -1,0 +1,23 @@
+package com.parkmate.notificationservice.notification.presentation;
+
+import com.parkmate.notificationservice.notification.application.NotificationService;
+import com.parkmate.notificationservice.notification.dto.NotificationEventDto;
+import com.parkmate.notificationservice.notification.event.NotificationEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class KafkaConsumerController {
+
+    private final NotificationService notificationService;
+
+    @KafkaListener(topics = "reservation.complete", groupId = "notification-service", containerFactory = "reservationCompleteEventListener")
+    public void consumeReservationCompleteEvent(NotificationEvent notificationEvent) {
+        log.info("Received message from reservation.complete topic: {}", notificationEvent);
+        notificationService.createNotification(NotificationEventDto.from(notificationEvent));
+    }
+}

--- a/src/main/java/com/parkmate/notificationservice/notification/presentation/KafkaConsumerController.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/presentation/KafkaConsumerController.java
@@ -16,7 +16,7 @@ public class KafkaConsumerController {
     private final NotificationService notificationService;
 
     @KafkaListener(topics = {"notification.created"}, groupId = "notification-service", containerFactory = "notificationEventListener")
-    public void consumeReservationCompleteEvent(NotificationEvent notificationEvent) {
+    public void consumeNotificationEvent(NotificationEvent notificationEvent) {
         log.info("Received message from reservation.complete topic: {}", notificationEvent);
         notificationService.createNotification(NotificationEventDto.from(notificationEvent));
     }

--- a/src/main/java/com/parkmate/notificationservice/notification/presentation/KafkaConsumerController.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/presentation/KafkaConsumerController.java
@@ -8,14 +8,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
-@RequiredArgsConstructor
-@Slf4j
 @Component
+@Slf4j
+@RequiredArgsConstructor
 public class KafkaConsumerController {
 
     private final NotificationService notificationService;
 
-    @KafkaListener(topics = "reservation.complete", groupId = "notification-service", containerFactory = "reservationCompleteEventListener")
+    @KafkaListener(topics = {"notification.created"}, groupId = "notification-service", containerFactory = "notificationEventListener")
     public void consumeReservationCompleteEvent(NotificationEvent notificationEvent) {
         log.info("Received message from reservation.complete topic: {}", notificationEvent);
         notificationService.createNotification(NotificationEventDto.from(notificationEvent));

--- a/src/main/java/com/parkmate/notificationservice/notification/presentation/KafkaConsumerController.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/presentation/KafkaConsumerController.java
@@ -15,7 +15,7 @@ public class KafkaConsumerController {
 
     private final NotificationService notificationService;
 
-    @KafkaListener(topics = {"notification.created"}, groupId = "notification-service", containerFactory = "notificationEventListener")
+    @KafkaListener(topics = {"reservation.created"}, groupId = "notification-service", containerFactory = "notificationEventListener")
     public void consumeNotificationEvent(NotificationEvent notificationEvent) {
         log.info("Received message from reservation.complete topic: {}", notificationEvent);
         notificationService.createNotification(NotificationEventDto.from(notificationEvent));

--- a/src/main/java/com/parkmate/notificationservice/notification/presentation/NotificationController.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/presentation/NotificationController.java
@@ -1,0 +1,29 @@
+package com.parkmate.notificationservice.notification.presentation;
+
+import com.parkmate.notificationservice.notification.application.NotificationService;
+import com.parkmate.notificationservice.notification.dto.response.NotificationResponseDto;
+import com.parkmate.notificationservice.notification.vo.response.NotificationResponseVo;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public List<NotificationResponseVo> getNotifications(@RequestParam String receiverUuid) {
+        return notificationService.getNotificationsByReceiverUuid(receiverUuid)
+                .stream()
+                .map(NotificationResponseDto::toVo)
+                .toList();
+    }
+}

--- a/src/main/java/com/parkmate/notificationservice/notification/vo/response/NotificationResponseVo.java
+++ b/src/main/java/com/parkmate/notificationservice/notification/vo/response/NotificationResponseVo.java
@@ -1,0 +1,23 @@
+package com.parkmate.notificationservice.notification.vo.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NotificationResponseVo {
+
+    private String title;
+    private String content;
+    private boolean isRead;
+
+    @Builder
+    private NotificationResponseVo(String title,
+                                  String content,
+                                  boolean isRead) {
+        this.title = title;
+        this.content = content;
+        this.isRead = isRead;
+    }
+}

--- a/src/test/java/com/parkmate/notificationservice/NotificationServiceApplicationTests.java
+++ b/src/test/java/com/parkmate/notificationservice/NotificationServiceApplicationTests.java
@@ -1,4 +1,4 @@
-package com.parkmate.notification_service;
+package com.parkmate.notificationservice;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Isuue Number) -->
#1 

## 💡 PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 기타 사소한 변경

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 변경 사항에 대한 테스트를 지켰는가
- [x] 커밋 메시지가 팀 컨벤션을 지켰는가
- [x] 브랜치 명이 규칙에 맞는가
- [x] 기능 정상 동작 확인 완료

##  📝 작업 내용
1. Notification 엔티티 정의
2. reservation-service로부터 발행된 'notification.created' 토픽을 구독하고 데이터 저장
